### PR TITLE
Fix deprecation warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## ⚠️ Deprecation Warning ⚠️
 
-This Action causes issues for users uploading test analytics to Codecov and will be deprecated in favor of the [Codecov action](https://github.com/codecov/codecov-action).
-To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report-type: test_results` as a parameter.
+> [!WARNING] 
+> This Action causes issues for users uploading test analytics to Codecov and will be deprecated in favor of the [Codecov action](https://github.com/codecov/codecov-action).
+> To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report_type: test_results` as a parameter.
 
 ## Usage
 


### PR DESCRIPTION
- Fix incorrect input name.
  https://github.com/codecov/codecov-action/blob/671740ac38dd9b0130fbe1cec585b89eea48d3de/action.yml#L121
- Use native GitHub markdown warning rendering.
