### PR TITLE
Fix README deprecation notice input name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## ⚠️ Deprecation Warning ⚠️
 
 This Action causes issues for users uploading test analytics to Codecov and will be deprecated in favor of the [Codecov action](https://github.com/codecov/codecov-action).
-To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report-type: test_results` as a parameter.
+To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report_type: test_results` as a parameter.
 
 ## Usage
 


### PR DESCRIPTION
Fixes a typo in the README deprecation notice: `report-type:` -> `report_type:` (matches the uploader CLI input).

Fixes #134.