### PR TITLE
fix(docs): correct report-type to report_type in deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## ⚠️ Deprecation Warning ⚠️
 
 This Action causes issues for users uploading test analytics to Codecov and will be deprecated in favor of the [Codecov action](https://github.com/codecov/codecov-action).
-To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report-type: test_results` as a parameter.
+To migrate to using this action, replace `codecov/test-results-action@v?` in your CI pipeline with `codecov/codecov-action@v5` and add `report_type: test_results` as a parameter.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Fixes a typo in the README deprecation notice: the migration instructions reference `report-type: test_results` but the correct GitHub Action input parameter is `report_type` (with an underscore, not a hyphen).

This was confirmed by checking the `action.yml` of `codecov/codecov-action`, which defines the input as `report_type`.

Closes #134

---

Contributed by [Sediman](https://sediman.com) — AI-powered video ads in seconds